### PR TITLE
Update os-maven-plugin to 1.6.0 / Fix build issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
-build/
+/build/
+/out/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/build.gradle
+++ b/build.gradle
@@ -8,12 +8,14 @@ description = 'A Gradle plugin that detects the OS name and architecture, provid
 group = 'com.google.gradle'
 
 // The major and minor versions are aligned with the Maven plugin's.
-version = '1.4.1-SNAPSHOT'
+version = '1.6.0-SNAPSHOT'
 
 dependencies {
-  compile gradleApi(),
-          localGroovy(),
-          'kr.motd.maven:os-maven-plugin:1.4.1.Final'
+  compile gradleApi(), localGroovy()
+  compile('kr.motd.maven:os-maven-plugin:1.6.0') {
+    exclude group: 'org.apache.maven', module: 'maven-plugin-api'
+    exclude group: 'org.codehaus.plexus', module: 'plexus-utils'
+  }
 }
 
 buildscript {
@@ -49,6 +51,10 @@ task groovydocJar(type: Jar, dependsOn:groovydoc) {
 task javadocJar(type: Jar, dependsOn:javadoc) {
   classifier = 'javadoc'
   from javadoc.destinationDir
+}
+
+tasks.javadoc.options {
+  addBooleanOption('Xdoclint:-missing').value = true
 }
 
 artifacts {

--- a/src/test/groovy/com/google/gradle/osdetector/OsDetectorPluginTest.groovy
+++ b/src/test/groovy/com/google/gradle/osdetector/OsDetectorPluginTest.groovy
@@ -35,7 +35,9 @@ class OsDetectorPluginTest {
     System.err.println('classifier=' + project.osdetector.classifier)
     if (project.osdetector.os == 'linux') {
       assertNotNull(project.osdetector.release.id)
-      assertNotNull(project.osdetector.release.version)
+      if (project.osdetector.release.id != 'arch') {
+        assertNotNull(project.osdetector.release.version)
+      }
       System.err.println('release.id=' + project.osdetector.release.id)
       System.err.println('release.version=' + project.osdetector.release.version)
       System.err.println('release.isLike(debian)=' + project.osdetector.release.isLike('debian'))


### PR DESCRIPTION
- Update os-maven-plugin to 1.6.0
- Fix Javadoc errors when building on Java 8
- Fix test failures when testing on Arch linux which doesn't have a version
- Miscellaneous:
  - Add /out/ to .gitignore, because it's used by IntelliJ IDEA