### PR TITLE
Update OMP dependency to 1.6.2 for z/OS detection

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext.pluginId = 'com.google.osdetector'
 
 dependencies {
   compile gradleApi(), localGroovy()
-  compile('kr.motd.maven:os-maven-plugin:1.6.0') {
+  compile('kr.motd.maven:os-maven-plugin:1.6.2') {
     exclude group: 'org.apache.maven', module: 'maven-plugin-api'
     exclude group: 'org.codehaus.plexus', module: 'plexus-utils'
   }


### PR DESCRIPTION
I've just helped add z/OS detection to os-maven-plugin. I'd like to use the new version so I can use Gradle builds with OS detection on z/OS.