### PR TITLE
Convert plugin class to Java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .gradle
 /build/
 /out/
+.idea/
 
 # Ignore Gradle GUI config
 gradle-app.setting

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk11
 
 script:
   - ./gradlew clean assemble test --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ sourceCompatibility = 1.8
 // Releases must be built on Java 1.8
 task checkJavaVersion {
   doLast {
-    if (!javaVersion.isJava8()) {
+    if (!javaVersion.java8Compatible) {
       throw new GradleException(
           "The plugin must be published under Java 1.8 but ${javaVersion} is found")
     }

--- a/src/main/java/com/google/gradle/osdetector/OsDetectorPlugin.java
+++ b/src/main/java/com/google/gradle/osdetector/OsDetectorPlugin.java
@@ -13,13 +13,16 @@
  *     See the License for the specific language governing permissions and
  *     limitations under the License.
  */
-package com.google.gradle.osdetector
+package com.google.gradle.osdetector;
 
-import org.gradle.api.Plugin
-import org.gradle.api.Project
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
 
-class OsDetectorPlugin implements Plugin<Project> {
-  void apply(final Project project) {
-    project.extensions.create('osdetector', OsDetector)
+public class OsDetectorPlugin implements Plugin<Project> {
+
+  @Override
+  public void apply(final Project project) {
+    project.getExtensions().create("osdetector", OsDetector.class);
   }
+
 }


### PR DESCRIPTION
No functional changes.

Groovy is great for tests, but I prefer Java for production code.

Updated CI config to build with openjdk11, but still produces java 8 bytecode.

Finally, tweaked `.gitignore` to stop tracking IntelliJ metadata.