### PR TITLE
Make plugin configuration cache compatible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext.pluginId = 'com.google.osdetector'
 
 dependencies {
   compile gradleApi(), localGroovy()
-  compile('kr.motd.maven:os-maven-plugin:1.6.2') {
+  compile('kr.motd.maven:os-maven-plugin:1.7.0') {
     exclude group: 'org.apache.maven', module: 'maven-plugin-api'
     exclude group: 'org.codehaus.plexus', module: 'plexus-utils'
   }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip

--- a/src/main/java/com/google/gradle/osdetector/OsDetectorPlugin.java
+++ b/src/main/java/com/google/gradle/osdetector/OsDetectorPlugin.java
@@ -22,7 +22,7 @@ public class OsDetectorPlugin implements Plugin<Project> {
 
   @Override
   public void apply(final Project project) {
-    project.getExtensions().create("osdetector", OsDetector.class);
+    project.getExtensions().create("osdetector", OsDetector.class, project);
   }
 
 }


### PR DESCRIPTION
Use Gradle's configuration cache compatible APIs for reading system properties and files:
- [reading system properties](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:undeclared_sys_prop_read)
- [reading files](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:undeclared_file_read)

This should be the upstream fix for https://github.com/google/protobuf-gradle-plugin/issues/409.

-----------------
This change includes prerequisites:
- Bump Gradle version to 6.5 for building with those APIs.
- Bump os-maven-plugin to 1.7.0 for https://github.com/trustin/os-maven-plugin/pull/47.