### PR TITLE
add detection of loongarch64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext.pluginId = 'com.google.osdetector'
 
 dependencies {
   compile gradleApi(), localGroovy()
-  compile('kr.motd.maven:os-maven-plugin:1.7.0') {
+  compile('kr.motd.maven:os-maven-plugin:1.7.1') {
     exclude group: 'org.apache.maven', module: 'maven-plugin-api'
     exclude group: 'org.codehaus.plexus', module: 'plexus-utils'
   }


### PR DESCRIPTION
"os-maven" has supported loongarch64, Elbrus 2000 arch in [os-maven-plugin-1.7.1](https://github.com/trustin/os-maven-plugin/releases/tag/os-maven-plugin-1.7.1)，i think osdetector-gradle-plugin also needs to support these