### PR TITLE
Added `toString` method in OsDetector.java

### DIFF
--- a/src/main/java/com/google/gradle/osdetector/OsDetector.java
+++ b/src/main/java/com/google/gradle/osdetector/OsDetector.java
@@ -192,4 +192,7 @@ public abstract class OsDetector {
       return new ByteArrayInputStream(bytes);
     }
   }
+
+  public String toString() {
+    return "os: " + getOs() + ", arch: " + getArch() + ", classifier: " + getClassifier();
 }


### PR DESCRIPTION
As titled, when you want to quickly get the properties printed with `println(osdetector)`

Ps: what about snake case, `osDetector`?